### PR TITLE
Added the basic lints

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -60,6 +60,7 @@ func New() *Linter {
 			rules.NewNoSameFileExtend(),
 			rules.NewKeyDirectivesLint(),
 			rules.NewMutationLint(),
+			rules.NewBasicLint(),
 		},
 		enabledRules: make(map[string]bool),
 	}

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -59,7 +59,7 @@ func TestNew(t *testing.T) {
 	}
 
 	// Check that all expected rules are loaded
-	expectedRuleCount := 29 // Based on the rules in the New() function
+	expectedRuleCount := 30 // Based on the rules in the New() function
 	if len(linter.rules) != expectedRuleCount {
 		t.Errorf("Expected %d rules, got %d", expectedRuleCount, len(linter.rules))
 	}

--- a/pkg/rules/basic_lint.go
+++ b/pkg/rules/basic_lint.go
@@ -1,0 +1,96 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/anirudhraja/gqllinter/pkg/types"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// BasicLint implements basic naming convention and type validation rules
+type BasicLint struct{}
+
+// NewBasicLint creates a new instance of BasicLint
+func NewBasicLint() *BasicLint {
+	return &BasicLint{}
+}
+
+// Name returns the name of this rule
+func (r *BasicLint) Name() string {
+	return "basic-lint"
+}
+
+// Description returns the description of this rule
+func (r *BasicLint) Description() string {
+	return "Validates basic naming conventions: @error types should not have 'Error' suffix (proto translation adds ErrorDetails), and no type should contain 'PropertiesBy' substring"
+}
+
+// Check performs the basic lint validation
+func (r *BasicLint) Check(schema *ast.Schema, source *ast.Source) []types.LintError {
+	var errors []types.LintError
+
+	// Check all types in the schema
+	for typeName, typeDefinition := range schema.Types {
+		// Skip built-in types
+		if typeDefinition.BuiltIn {
+			continue
+		}
+
+		// Rule 1: @error types shouldn't have 'Error' trailing in their names
+		if r.hasErrorDirective(typeDefinition) {
+			if r.hasErrorSuffix(typeName) {
+				errors = append(errors, types.LintError{
+					Message: fmt.Sprintf("Type '%s' has @error directive but contains 'Error' in its name. Remove the 'Error' suffix", typeName),
+					Location: types.Location{
+						Line:   typeDefinition.Position.Line,
+						Column: typeDefinition.Position.Column,
+						File:   source.Name,
+					},
+					Rule: r.Name(),
+				})
+			}
+		}
+
+		// Rule 2: No type should contain 'PropertiesBy' substring
+		if r.containsPropertiesBy(typeName) {
+			errors = append(errors, types.LintError{
+				Message: fmt.Sprintf("Type '%s' contains 'PropertiesBy' substring which is not allowed in type names", typeName),
+				Location: types.Location{
+					Line:   typeDefinition.Position.Line,
+					Column: typeDefinition.Position.Column,
+					File:   source.Name,
+				},
+				Rule: r.Name(),
+			})
+		}
+	}
+
+	return errors
+}
+
+// hasErrorDirective checks if a type has the @error directive
+func (r *BasicLint) hasErrorDirective(typeDefinition *ast.Definition) bool {
+	if typeDefinition == nil {
+		return false
+	}
+
+	for _, directive := range typeDefinition.Directives {
+		if directive.Name == "error" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasErrorSuffix checks if a type name has 'Error' suffix (case-insensitive)
+func (r *BasicLint) hasErrorSuffix(typeName string) bool {
+	lowerName := strings.ToLower(typeName)
+	return strings.HasSuffix(lowerName, "error")
+}
+
+// containsPropertiesBy checks if a type name contains 'PropertiesBy' substring (case-insensitive)
+func (r *BasicLint) containsPropertiesBy(typeName string) bool {
+	lowerName := strings.ToLower(typeName)
+	return strings.Contains(lowerName, "propertiesby")
+}

--- a/pkg/rules/basic_lint_test.go
+++ b/pkg/rules/basic_lint_test.go
@@ -1,0 +1,259 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestBasicLint(t *testing.T) {
+	tests := []struct {
+		name           string
+		schema         string
+		expectedErrors int
+		expectedMsg    string
+	}{
+		{
+			name: "Valid: @error types without Error suffix",
+			schema: `
+				directive @error on OBJECT
+
+				type UserNotFound @error {
+					code: String!
+					message: String!
+				}
+
+				type ProductUnavailable @error {
+					reason: String!
+				}
+
+				type RegularType {
+					id: ID!
+					name: String!
+				}
+			`,
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid: @error type with Error suffix",
+			schema: `
+				directive @error on OBJECT
+
+				type UserNotFoundError @error {
+					code: String!
+					message: String!
+				}
+
+				type RegularType {
+					id: ID!
+					name: String!
+				}
+			`,
+			expectedErrors: 1,
+			expectedMsg:    "Type 'UserNotFoundError' has @error directive but contains 'Error' in its name",
+		},
+		{
+			name: "Invalid: Multiple @error types with Error suffix",
+			schema: `
+				directive @error on OBJECT
+
+				type UserNotFoundError @error {
+					code: String!
+					message: String!
+				}
+
+				type ProductError @error {
+					reason: String!
+				}
+
+				type ValidationError @error {
+					field: String!
+					message: String!
+				}
+			`,
+			expectedErrors: 3,
+			expectedMsg:    "has @error directive but contains 'Error' in its name",
+		},
+		{
+			name: "Invalid: Case-insensitive Error suffix detection",
+			schema: `
+				directive @error on OBJECT
+
+				type UserNotFoundERROR @error {
+					code: String!
+					message: String!
+				}
+
+				type Producterror @error {
+					reason: String!
+				}
+			`,
+			expectedErrors: 2,
+			expectedMsg:    "has @error directive but contains 'Error' in its name",
+		},
+		{
+			name: "Valid: Regular types can have Error suffix",
+			schema: `
+				directive @error on OBJECT
+
+				type UserNotFoundError {
+					code: String!
+					message: String!
+				}
+
+				type SystemError {
+					level: String!
+					description: String!
+				}
+			`,
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid: Type contains PropertiesBy substring",
+			schema: `
+				directive @error on OBJECT
+
+				type UserPropertiesByLocation {
+					location: String!
+					users: [String!]!
+				}
+
+				type RegularType {
+					id: ID!
+					name: String!
+				}
+			`,
+			expectedErrors: 1,
+			expectedMsg:    "Type 'UserPropertiesByLocation' contains 'PropertiesBy' substring which is not allowed",
+		},
+		{
+			name: "Invalid: Multiple types with PropertiesBy substring",
+			schema: `
+				directive @error on OBJECT
+
+				type UserPropertiesByLocation {
+					location: String!
+					users: [String!]!
+				}
+
+				type ProductPropertiesByCategory {
+					category: String!
+					products: [String!]!
+				}
+
+				type OrderPropertiesByStatus {
+					status: String!
+					orders: [String!]!
+				}
+			`,
+			expectedErrors: 3,
+			expectedMsg:    "contains 'PropertiesBy' substring which is not allowed",
+		},
+		{
+			name: "Invalid: Case-insensitive PropertiesBy detection",
+			schema: `
+				directive @error on OBJECT
+
+				type UserpropertiesbyLocation {
+					location: String!
+					users: [String!]!
+				}
+
+				type ProductPROPERTIESBYCategory {
+					category: String!
+					products: [String!]!
+				}
+
+				type OrderPropertiesByStatus {
+					status: String!
+					orders: [String!]!
+				}
+			`,
+			expectedErrors: 3,
+			expectedMsg:    "contains 'PropertiesBy' substring which is not allowed",
+		},
+		{
+			name: "Invalid: Both Error suffix and PropertiesBy violations",
+			schema: `
+				directive @error on OBJECT
+
+				type UserNotFoundError @error {
+					code: String!
+					message: String!
+				}
+
+				type ProductPropertiesByCategory {
+					category: String!
+					products: [String!]!
+				}
+
+				type ValidationError @error {
+					field: String!
+					message: String!
+				}
+
+				type OrderPropertiesByStatusError @error {
+					status: String!
+					orders: [String!]!
+				}
+			`,
+			expectedErrors: 5,  // OrderPropertiesByStatusError triggers both Error suffix and PropertiesBy violations
+			expectedMsg:    "", // Will check individual messages
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create source from schema string
+			source := &ast.Source{
+				Name:  "test-schema.graphql",
+				Input: tt.schema,
+			}
+
+			// Parse the schema
+			schema, err := gqlparser.LoadSchema(source)
+			if err != nil {
+				t.Fatalf("Failed to parse schema: %v", err)
+			}
+
+			// Create and run the rule
+			rule := NewBasicLint()
+			errors := rule.Check(schema, source)
+
+			// Check error count
+			if len(errors) != tt.expectedErrors {
+				t.Errorf("Expected %d errors, but got %d", tt.expectedErrors, len(errors))
+				for i, e := range errors {
+					t.Errorf("Error %d: %s", i+1, e.Message)
+				}
+				return
+			}
+
+			// Check error message if specified
+			if tt.expectedErrors > 0 && tt.expectedMsg != "" {
+				found := false
+				for _, e := range errors {
+					if strings.Contains(e.Message, tt.expectedMsg) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected error message to contain '%s', but got:", tt.expectedMsg)
+					for i, e := range errors {
+						t.Errorf("Error %d: %s", i+1, e.Message)
+					}
+				}
+			}
+
+			// Check that all errors have the correct rule name
+			for _, e := range errors {
+				if e.Rule != rule.Name() {
+					t.Errorf("Expected rule name '%s', but got '%s'", rule.Name(), e.Rule)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. @error types shouldn’t have error name trailing in their names (since we would anyway append ErrorDetails in their proto translation ) LINT_ERROR
2. PropertiesBy shouldn’t be a substring for any schema LINT_ERROR