### PR TITLE
update operation input name rule

### DIFF
--- a/pkg/rules/operation_input_name.go
+++ b/pkg/rules/operation_input_name.go
@@ -60,7 +60,7 @@ func (r *InputName) checkFields(fields ast.FieldList, operationType string, sour
 				arg := field.Arguments[0]
 
 				// Check if the argument is named "request"
-				if arg.Name != "request" {
+				if arg.Name != "input" {
 					line, column := 1, 1
 					if arg.Position != nil {
 						line = arg.Position.Line
@@ -68,7 +68,7 @@ func (r *InputName) checkFields(fields ast.FieldList, operationType string, sour
 					}
 
 					errors = append(errors, types.LintError{
-						Message: fmt.Sprintf("%s `%s` argument should be named 'request', not '%s'.", operationType, field.Name, arg.Name),
+						Message: fmt.Sprintf("%s `%s` argument should be named 'input', not '%s'.", operationType, field.Name, arg.Name),
 						Location: types.Location{
 							Line:   line,
 							Column: column,
@@ -109,7 +109,7 @@ func (r *InputName) checkFields(fields ast.FieldList, operationType string, sour
 
 				//expectedInputType := r.capitalizeFirst(field.Name) + "Request"
 				errors = append(errors, types.LintError{
-					Message: fmt.Sprintf("%s `%s` has %d arguments. Consider consolidating into a single 'request' argument of a properly named input type (not %sRequest).", operationType, field.Name, len(field.Arguments), r.capitalizeFirst(field.Name)),
+					Message: fmt.Sprintf("%s `%s` has %d arguments. Consider consolidating into a single 'input' argument of a properly named input type (not %sRequest).", operationType, field.Name, len(field.Arguments), r.capitalizeFirst(field.Name)),
 					Location: types.Location{
 						Line:   line,
 						Column: column,

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -730,13 +730,13 @@ func TestInputName(t *testing.T) {
 	t.Run("should flag input types with Request suffix", func(t *testing.T) {
 		schema := `
 		type Query {
-			getUser(request: GetUserRequest!): User
-			listUsers(request: ListUsersRequest!): [User!]!
+			getUser(input: GetUserRequest!): User
+			listUsers(input: ListUsersRequest!): [User!]!
 		}
 
 		type Mutation {
-			createUser(request: CreateUserRequest!): User!
-			updateUser(request: UpdateUserRequest!): User!
+			createUser(input: CreateUserRequest!): User!
+			updateUser(input: UpdateUserRequest!): User!
 		}
 
 		type User {
@@ -774,12 +774,12 @@ func TestInputName(t *testing.T) {
 	t.Run("should flag versioned Request input types", func(t *testing.T) {
 		schema := `
 		type Query {
-			getUser(request: GetUserRequestV2!): User
-			listUsers(request: ListUsersRequestVersion3!): [User!]!
+			getUser(input: GetUserRequestV2!): User
+			listUsers(input: ListUsersRequestVersion3!): [User!]!
 		}
 
 		type Mutation {
-			createUser(request: CreateUserRequestV1!): User!
+			createUser(input: CreateUserRequestV1!): User!
 		}
 
 		type User {
@@ -832,7 +832,7 @@ func TestInputName(t *testing.T) {
 	t.Run("should flag incorrect argument names and Request suffix types", func(t *testing.T) {
 		schema := `
 		type Query {
-			getUser(input: GetUserRequest!): User
+			getUser(request: GetUserRequest!): User
 			listUsers(params: ListUsersRequest!): [User!]!
 		}
 
@@ -866,12 +866,12 @@ func TestInputName(t *testing.T) {
 	t.Run("should pass with proper input type names without Request suffix", func(t *testing.T) {
 		schema := `
 		type Query {
-			getUser(request: UserInput!): User
-			listUsers(request: UsersFilter!): [User!]!
+			getUser(input: UserInput!): User
+			listUsers(input: UsersFilter!): [User!]!
 		}
 
 		type Mutation {
-			createUser(request: NewUserData!): User!
+			createUser(input: NewUserData!): User!
 		}
 
 		type User {
@@ -921,13 +921,13 @@ func TestInputName(t *testing.T) {
 	t.Run("should handle mixed valid and invalid cases", func(t *testing.T) {
 		schema := `
 		type Query {
-			getUser(request: GetUserRequest!): User
+			getUser(input: GetUserRequest!): User
 			listUsers(input: ListUsersRequest!): [User!]!
 			searchUsers(query: String!, limit: Int): [User!]!
 		}
 
 		type Mutation {
-			createUser(request: CreateUserRequest!): User!
+			createUser(input: CreateUserRequest!): User!
 			updateUser(data: UpdateUserInput!): User!
 		}
 
@@ -954,8 +954,8 @@ func TestInputName(t *testing.T) {
 		`
 		errors := runRule(t, rule, schema)
 		errorCount := countRuleErrors(errors, "operation-input-name")
-		if errorCount != 6 {
-			t.Errorf("Expected 6 errors (3 Request suffix types + 2 wrong argument names + 1 multiple arguments), got %d", errorCount)
+		if errorCount != 5 {
+			t.Errorf("Expected 6 errors (3 Request suffix types + 1 wrong argument names + 1 multiple arguments), got %d", errorCount)
 		}
 	})
 }


### PR DESCRIPTION
- The argument name for an operation should be `input` 