### PR TITLE
Update mutation-lint rule to remove non-null response type check 

### DIFF
--- a/pkg/rules/mutation_lint.go
+++ b/pkg/rules/mutation_lint.go
@@ -84,19 +84,6 @@ func (r *MutationLint) validateMutationResponseUnions(schema *ast.Schema, source
 			})
 			continue
 		}
-		// should be non-null type
-		if !field.Type.NonNull {
-			errors = append(errors, types.LintError{
-				Message: fmt.Sprintf("Mutation field '%s' must return a non-null union type with @responseUnion directive, but returns '%s'", field.Name, returnTypeName),
-				Location: types.Location{
-					Line:   field.Position.Line,
-					Column: field.Position.Column,
-					File:   source.Name,
-				},
-				Rule: r.Name(),
-			})
-			continue
-		}
 
 		// Check if the union has @responseUnion directive
 		if !r.hasResponseUnionDirective(returnType) {

--- a/pkg/rules/mutation_lint_test.go
+++ b/pkg/rules/mutation_lint_test.go
@@ -95,7 +95,7 @@ func TestMutationLint(t *testing.T) {
 				}
 
 				type Mutation {
-					resolveMobileRiders(id: ID!): MockMobileRider!
+					resolveMobileRiders(id: ID!): MockMobileRider
 				}
 			`,
 			expectedErrors: 1,
@@ -175,7 +175,7 @@ func TestMutationLint(t *testing.T) {
 				}
 
 				type Mutation {
-					resolveMobileRiders(id: ID!): MobileRiders!
+					resolveMobileRiders(id: ID!): MobileRiders
 				}
 			`,
 			expectedErrors: 1,
@@ -314,7 +314,7 @@ func TestMutationLint(t *testing.T) {
 
 				type Mutation {
 					mutation1(id: ID!): BadUnion1!
-					mutation2(id: ID!): BadUnion2!
+					mutation2(id: ID!): BadUnion2
 					mutation3(id: ID!): Success1!
 				}
 			`,


### PR DESCRIPTION
- Update mutation-lint rule to remove non-null response type check from mutation response
- Nullability check is handled by mutation-response-nullable https://github.com/anirudhraja/gqllinter/pull/37
- All unit tests are not updated to match the nullability requirement since this rule doesn't handle that check
  - Test schemas have a mix of nullable and non-nullable mutation response fields